### PR TITLE
領収書ダウンロードのロジックを修正

### DIFF
--- a/module/amazon_login_automation.py
+++ b/module/amazon_login_automation.py
@@ -56,4 +56,4 @@ class amazonLoginAutomation:
         # #「ログイン」をクリック
         nextb = driver.find_element(By.ID, "auth-signin-button")
         nextb.click()
-        time.sleep(10)
+        time.sleep(1)


### PR DESCRIPTION
# やったこと

- アマゾン領収証ダウンロードのスクレイピング処理を修正
- ExceptionありきのWhileブレーク処理が危なすぎたのでMax件数を取得しMax分ループするように処理を改善
